### PR TITLE
feat(dns): Master file parsing ✨

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# JASER
+<h1 align="center">JASER - Java Servers</h1>
+
+<p align="center">
+    <img alt="forthebadge" src="https://forthebadge.com/images/badges/made-with-java.svg" />
+    <img alt="forthebadge" src="https://forthebadge.com/images/badges/built-by-developers.svg" />
+</p>    
+<p align="center">
+    <a href="https://github.com/dederobert/JASER/actions/workflows/maven.yml" title="Java CI with Maven"><img alt="Java CI with Maven" src="https://github.com/dederobert/JASER/actions/workflows/maven.yml/badge.svg?branch=main" /></a>
+    <img alt="Java version" src="https://img.shields.io/badge/java%20-%3E%3D%2017-brightgreen" />
+</p>
+
+Collection of several Java servers.
+
+## About
+
+Jaser is a collection of several Java servers. It includes:
+
+- DNS Server
+
+Planned:
+
+- DHCP Server

--- a/dns/src/main/java/fr/lehtto/jaser/dns/StartCommand.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/StartCommand.java
@@ -24,11 +24,12 @@ public class StartCommand implements Runnable {
 
   private static final Logger LOG = LogManager.getLogger(StartCommand.class);
 
+  @SuppressWarnings("MismatchedReadAndWriteOfArray")
   @Option(
-      names = {"F", "file"},
-      defaultValue = "dnsZone.txt",
-      description = "File containing the DNS zone")
-  private File file;
+      names = {"-F", "--file"},
+      paramLabel = "FILE",
+      description = "One or more DNS zone files to load")
+  private File[] files;
 
   @Parameters(index = "0", arity = "0..1", defaultValue = "localhost", description = "AddressV4 of the DNS server")
   private InetAddress ip;
@@ -53,11 +54,8 @@ public class StartCommand implements Runnable {
   @Override
   public void run() {
     // Create a new DNS server and start it
-    try {
+    for (final File file : files) {
       Dns.INSTANCE.load(file);
-    } catch (final IOException ex) {
-      LOG.error("Error while loading the DNS zone", ex);
-      return;
     }
     Dns.INSTANCE.start(ip, port);
 

--- a/dns/src/main/java/fr/lehtto/jaser/dns/console/RecordsCommandHandler.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/console/RecordsCommandHandler.java
@@ -3,6 +3,8 @@ package fr.lehtto.jaser.dns.console;
 import fr.lehtto.jaser.core.console.command.CommandHandler;
 import fr.lehtto.jaser.core.utils.BeautifulListLogger;
 import fr.lehtto.jaser.dns.Dns;
+import fr.lehtto.jaser.dns.master.file.MasterFile;
+import java.util.Collection;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author lehtto
  * @version 0.2.0
+ * @since 0.1.0
  */
 public class RecordsCommandHandler extends CommandHandler {
 
@@ -34,7 +37,8 @@ public class RecordsCommandHandler extends CommandHandler {
       return false;
     }
 
-    BeautifulListLogger.log(LOG, Level.INFO, "Resource records", Dns.INSTANCE.getMasterFile());
+    BeautifulListLogger.log(LOG, Level.INFO, "Resource records",
+        Dns.INSTANCE.getMasterFiles().stream().map(MasterFile::getRecords).flatMap(Collection::stream).toList());
     return true;
   }
 }

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/LineParser.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/LineParser.java
@@ -1,0 +1,74 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import fr.lehtto.jaser.dns.entity.parser.InvalidDnsZoneEntryException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parse a line of a DNS zone file.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+final class LineParser {
+
+  /**
+   * Default constructor.
+   */
+  private LineParser() {
+    throw new AssertionError("This constructor should not be called.");
+  }
+
+  /**
+   * Generates tokens from a line of a DNS zone file.
+   *
+   * @param line the line to parse.
+   * @return the list of tokens.
+   * @throws InvalidDnsZoneEntryException if the line is invalid.
+   */
+  static List<Token> tokenize(final @NotNull String line) throws InvalidDnsZoneEntryException {
+    TokenizeStateMachine state = TokenizeStateMachine.START;
+    TokenizeStateMachine previousState = state;
+    final List<Token> tokens = new ArrayList<>();
+    StringBuilder sb = new StringBuilder(10);
+
+    for (final char c : line.toCharArray()) {
+      state = state.next(c);
+      if (TokenizeStateMachine.INVALID == state) {
+        throw new InvalidDnsZoneEntryException("Invalid character: " + c);
+      }
+      if (previousState != state) {
+        // Add state if it's not the same as the last one
+        tokens.add(new Token(sb.toString(), previousState.getType()));
+        sb = new StringBuilder(10);
+        previousState = state;
+      }
+      sb.append(c);
+    }
+    // Add last token
+    tokens.add(new Token(sb.toString(), state.getType()));
+    return tokens;
+  }
+
+  /**
+   * Parse tokens into a DNS zone entry.
+   *
+   * @param tokens the tokens to parse.
+   * @return the DNS zone entry.
+   */
+  static List<ParsedToken> parseToken(final @NotNull List<Token> tokens) {
+    final int tokenListSize = tokens.size();
+    final List<ParsedToken> states = new ArrayList<>(tokenListSize);
+    ParseTokenStateMachine state = ParseTokenStateMachine.START;
+
+    for (int i = 1; i < tokenListSize; i++) {
+      final Token token = tokens.get(i);
+      if (TokenType.SPACE != token.type()) {
+        state = state.next(token);
+        states.add(new ParsedToken(token.value(), state));
+      }
+    }
+    return states;
+  }
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/MasterFile.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/MasterFile.java
@@ -1,0 +1,89 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import fr.lehtto.jaser.dns.entity.ResourceRecord;
+import fr.lehtto.jaser.dns.entity.enumration.DnsClass;
+import fr.lehtto.jaser.dns.entity.enumration.Type;
+import fr.lehtto.jaser.dns.entity.parser.InvalidDnsZoneEntryException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
+
+/**
+ * DNS master file.
+ *
+ * @author lehtto
+ * @version 0.2.0
+ */
+public class MasterFile {
+
+  private final List<ResourceRecord> records = new ArrayList<>();
+  private DnsClass dnsClass;
+
+
+  /**
+   * Adds a record to the master file.
+   *
+   * @param resourceRecord the resource record to add
+   * @throws InvalidDnsZoneEntryException if the record is invalid
+   */
+  void addRecord(final @NotNull ResourceRecord resourceRecord) throws InvalidDnsZoneEntryException {
+    // Check if the record is valid.
+    if (null == dnsClass) {
+      dnsClass = resourceRecord.recordClass();
+    } else if (dnsClass != resourceRecord.recordClass()) {
+      // The record class is not the same as the master file's class.
+      throw new InvalidDnsZoneEntryException("The record class is not the same as the master file's class.");
+    }
+
+    if (Type.SOA == resourceRecord.type() && isSoaPresent()) {
+      // The SOA record is already present.
+      throw new InvalidDnsZoneEntryException("The SOA record is already present.");
+    }
+
+    records.add(resourceRecord);
+  }
+
+  /**
+   * Checks if SOA record is already present.
+   *
+   * @return true if SOA record is already present, false otherwise
+   */
+  private boolean isSoaPresent() {
+    // Check if the record is valid.
+    return records.stream().map(ResourceRecord::type).anyMatch(Predicate.isEqual(Type.SOA));
+  }
+
+  /**
+   * Gets the zone's size.
+   *
+   * @return the zone's size
+   */
+  public int size() {
+    return records.size();
+  }
+
+  /**
+   * Gets the zone's records.
+   *
+   * @return the zone's records
+   */
+  @UnmodifiableView
+  public @NotNull List<ResourceRecord> getRecords() {
+    return List.copyOf(records);
+  }
+
+  /**
+   * Sets the zone's records.
+   *
+   * @param resourceRecords the zone's records
+   */
+  public void setResourceRecords(final @Nullable List<ResourceRecord> resourceRecords) {
+    records.clear();
+    if (null != resourceRecords) {
+      records.addAll(resourceRecords);
+    }
+  }
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/MasterFileParser.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/MasterFileParser.java
@@ -1,0 +1,253 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import fr.lehtto.jaser.dns.entity.ResourceRecord;
+import fr.lehtto.jaser.dns.entity.enumration.DnsClass;
+import fr.lehtto.jaser.dns.entity.enumration.Type;
+import fr.lehtto.jaser.dns.entity.parser.InvalidDnsZoneEntryException;
+import fr.lehtto.jaser.dns.entity.rdata.RDataFactory;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Parser for DNS master file.
+ *
+ * @author lehtto
+ * @version 0.2.0
+ */
+public final class MasterFileParser {
+
+  private static final Logger LOG = LogManager.getLogger(MasterFileParser.class);
+
+  /**
+   * Default constructor.
+   */
+  private MasterFileParser() {
+    throw new AssertionError("This constructor should not be called.");
+  }
+
+  /**
+   * Parses a DNS master file.
+   *
+   * @param masterFile the master file to parse
+   * @return the parsed master file
+   * @throws InvalidDnsZoneEntryException if the master file is invalid
+   */
+  public static @NotNull MasterFile parse(final File masterFile) throws InvalidDnsZoneEntryException {
+    // Determine the zone name from the file name.
+    final String domain;
+    if (masterFile.getName().endsWith(".zone")) {
+      domain = masterFile.getName().substring(0, masterFile.getName().length() - 5);
+    } else {
+      LOG.warn("Please consider using a .zone file.");
+      domain = masterFile.getName();
+    }
+
+    // Read the file.
+    final List<String> lines = readLines(masterFile);
+    // Create the master file.
+    final MasterFile master = new MasterFile();
+
+    // Parse the file.
+    final ParserInputContext parserInputContext = new ParserInputContext(lines, domain);
+    while (parserInputContext.hasNextLine()) {
+      final String line = parserInputContext.nextLine();
+      if (line.isEmpty()) {
+        continue;
+      }
+
+      // Tokenize the line.
+      final List<Token> tokens = LineParser.tokenize(line);
+      // Parse tokens.
+      final List<ParsedToken> parsedTokens = LineParser.parseToken(tokens);
+
+      if (ParseTokenStateMachine.COMMENT == parsedTokens.get(0).type()) {
+        // This is a comment line.
+        continue;
+      }
+
+      if (ParseTokenStateMachine.CONTROL == parsedTokens.get(0).type()) {
+        // This is a control line.
+        handleControlLine(masterFile, parsedTokens, parserInputContext);
+        continue;
+      }
+
+      // This is a resource record line.
+      final String recordDomain = retrieveDomain(parserInputContext, parsedTokens);
+      final Type type = retrieveType(parsedTokens);
+      final int ttl = retrieveTtl(parserInputContext, parsedTokens);
+      final DnsClass dnsClass = retrieveClass(parserInputContext, parsedTokens);
+      final String[] data = retrieveData(parsedTokens);
+
+      final ResourceRecord resourceRecord = ResourceRecord.builder()
+          .name(recordDomain)
+          .type(type)
+          .ttl(ttl)
+          .recordClass(dnsClass)
+          .data(RDataFactory.create(type, data))
+          .build();
+
+      master.addRecord(resourceRecord);
+    }
+    return master;
+  }
+
+  /**
+   * Handles a control line.
+   *
+   * @param masterFile         the master file to parse
+   * @param parsedTokens       the parsed tokens
+   * @param parserInputContext the parser input context
+   * @throws InvalidDnsZoneEntryException if the master file is invalid
+   */
+  private static void handleControlLine(final @NotNull File masterFile,
+      final @NotNull List<ParsedToken> parsedTokens, final @NotNull ParserInputContext parserInputContext)
+      throws InvalidDnsZoneEntryException {
+    LOG.debug("Control line: {}", parsedTokens);
+    switch (parsedTokens.get(0).value()) {
+      case "$INCLUDE" -> {
+        final String fileName = parsedTokens.get(1).value();
+        final File file = new File(masterFile.getParent(), fileName);
+        final List<String> includedLines = readLines(file);
+        parserInputContext.addLines(includedLines);
+        LOG.debug("Included file: {}", file);
+      }
+      case "$ORIGIN" -> {
+        final String origin = parsedTokens.get(1).value();
+        parserInputContext.setDomain(origin);
+        LOG.debug("Origin: {}", origin);
+      }
+      case "$TTL" -> {
+        final int ttl = Integer.parseInt(parsedTokens.get(1).value());
+        parserInputContext.setTtl(ttl);
+        LOG.debug("TTL: {}", ttl);
+      }
+      case "$CLASS" -> {
+        final DnsClass dnsClass = DnsClass.valueOf(parsedTokens.get(1).value());
+        parserInputContext.setDnsClass(dnsClass);
+        LOG.debug("Class: {}", dnsClass);
+      }
+      default -> throw new InvalidDnsZoneEntryException("Unknown control line: " + parsedTokens);
+    }
+  }
+
+  /**
+   * Reads the lines of a file.
+   *
+   * @param file the file to read
+   * @return the lines of the file
+   */
+  private static List<String> readLines(final @NotNull File file) {
+    // Read the file.
+    final List<String> lines = new ArrayList<>();
+    try (final Scanner scanner = new Scanner(file, StandardCharsets.UTF_8)) {
+      while (scanner.hasNextLine()) {
+        final String line = scanner.nextLine();
+        lines.add(line);
+      }
+    } catch (final IOException e) {
+      LOG.warn("Could not read file.", e);
+    }
+    return lines;
+  }
+
+  /**
+   * Retrieves the domain from the parsed tokens or stated domain.
+   *
+   * @param parserInputContext the parser input context
+   * @param parsedTokens       the parsed tokens
+   * @return the domain
+   */
+  private static @NotNull String retrieveDomain(final @NotNull ParserInputContext parserInputContext,
+      final @NotNull List<ParsedToken> parsedTokens) {
+
+    final String domain = parsedTokens.stream()
+        .filter(token -> ParseTokenStateMachine.DOMAIN == token.type())
+        .map(ParsedToken::value)
+        .findFirst().orElse("");
+
+    // If domain ends with a dot, it is absolute.
+    if (domain.endsWith(".")) {
+      return domain;
+    }
+
+    if (domain.isEmpty()) {
+      return parserInputContext.getDomain();
+    }
+    return domain + '.' + parserInputContext.getDomain();
+  }
+
+  /**
+   * Retrieves the type from the parsed tokens.
+   *
+   * @param parsedTokens the parsed tokens
+   * @return the type
+   * @throws InvalidDnsZoneEntryException if the type is not found
+   */
+  private static @NotNull Type retrieveType(final @NotNull List<ParsedToken> parsedTokens)
+      throws InvalidDnsZoneEntryException {
+    return parsedTokens.stream()
+        .filter(token -> ParseTokenStateMachine.TYPE == token.type())
+        .map(ParsedToken::value)
+        .findFirst()
+        .map(Type::valueOf)
+        .orElseThrow(() -> new InvalidDnsZoneEntryException("Could not determine type."));
+  }
+
+  /**
+   * Retrieves the TTL from the parsed tokens or stated TTL.
+   *
+   * @param parserInputContext the parser input context
+   * @param parsedTokens       the parsed tokens
+   * @return the TTL
+   */
+  private static int retrieveTtl(final @NotNull ParserInputContext parserInputContext,
+      final @NotNull List<ParsedToken> parsedTokens) {
+    final Integer ttl = parsedTokens.stream()
+        .filter(token -> ParseTokenStateMachine.TTL == token.type())
+        .map(ParsedToken::value)
+        .findFirst()
+        .map(Integer::parseInt)
+        .orElseGet(parserInputContext::getTtl);
+    assert null != ttl : "TTL should not be null.";
+    return ttl;
+  }
+
+  /**
+   * Retrieves the DNS class from the parsed tokens or stated DNS class.
+   *
+   * @param parserInputContext the parser input context
+   * @param parsedTokens       the parsed tokens
+   * @return the DNS class
+   */
+  private static @NotNull DnsClass retrieveClass(final @NotNull ParserInputContext parserInputContext,
+      final @NotNull List<ParsedToken> parsedTokens) {
+    final DnsClass dnsClass = parsedTokens.stream()
+        .filter(token -> ParseTokenStateMachine.CLASS == token.type())
+        .map(ParsedToken::value)
+        .findFirst()
+        .map(DnsClass::valueOf)
+        .orElseGet(parserInputContext::getDnsClass);
+    assert null != dnsClass : "DnsClass should not be null.";
+    return dnsClass;
+  }
+
+  /**
+   * Retrieves the data from the parsed tokens.
+   *
+   * @param parsedTokens the parsed tokens
+   * @return the data
+   */
+  private static String @NotNull [] retrieveData(final @NotNull List<ParsedToken> parsedTokens) {
+    return parsedTokens.stream()
+        .filter(token -> ParseTokenStateMachine.DATA == token.type())
+        .map(ParsedToken::value)
+        .toArray(String[]::new);
+  }
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParseTokenStateMachine.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParseTokenStateMachine.java
@@ -1,0 +1,128 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import fr.lehtto.jaser.core.utils.EnumUtils;
+import fr.lehtto.jaser.core.utils.NumberUtils;
+import fr.lehtto.jaser.dns.entity.enumration.DnsClass;
+import fr.lehtto.jaser.dns.entity.enumration.Type;
+
+/**
+ * State machine for parsing a {@link Token}.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+enum ParseTokenStateMachine {
+  START {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      if (TokenType.DATA == token.type()) {
+        if (NumberUtils.isParsable(token.value())) {
+          return TTL;
+        }
+        if (EnumUtils.isValidEnum(Type.class, token.value())) {
+          return TYPE;
+        }
+        if (EnumUtils.isValidEnum(DnsClass.class, token.value())) {
+          return CLASS;
+        }
+        return INVALID;
+      }
+      return switch (token.type()) {
+        case DOMAIN -> DOMAIN;
+        case COMMENT -> COMMENT;
+        case CONTROL -> CONTROL;
+        default -> INVALID;
+      };
+    }
+  },
+  DOMAIN {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      if (TokenType.DATA == token.type()) {
+        if (NumberUtils.isParsable(token.value())) {
+          return TTL;
+        }
+        if (EnumUtils.isValidEnum(Type.class, token.value())) {
+          return TYPE;
+        }
+        if (EnumUtils.isValidEnum(DnsClass.class, token.value())) {
+          return CLASS;
+        }
+      }
+      return INVALID;
+    }
+  },
+  TTL {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      if (TokenType.DATA == token.type()) {
+        if (EnumUtils.isValidEnum(Type.class, token.value())) {
+          return TYPE;
+        }
+        if (EnumUtils.isValidEnum(DnsClass.class, token.value())) {
+          return CLASS;
+        }
+      }
+      return INVALID;
+    }
+  },
+  TYPE {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      if (TokenType.DATA == token.type() || TokenType.QUOTE == token.type()) {
+        return DATA;
+      }
+      return INVALID;
+    }
+  },
+  CLASS {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      if (TokenType.DATA == token.type()) {
+        if (NumberUtils.isParsable(token.value())) {
+          return TTL;
+        }
+        if (EnumUtils.isValidEnum(Type.class, token.value())) {
+          return TYPE;
+        }
+      }
+      return INVALID;
+    }
+  },
+  DATA {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      return switch (token.type()) {
+        case DATA, QUOTE, END_QUOTE -> DATA;
+        case COMMENT -> COMMENT;
+        default -> INVALID;
+      };
+    }
+  },
+  COMMENT {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      return null;
+    }
+  },
+  CONTROL {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      return DATA;
+    }
+  },
+  INVALID {
+    @Override
+    public ParseTokenStateMachine next(final Token token) {
+      return INVALID;
+    }
+  };
+
+  /**
+   * Gets the next state based on token type.
+   *
+   * @param token the token to get the next state from.
+   * @return the next state
+   */
+  public abstract ParseTokenStateMachine next(final Token token);
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParsedToken.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParsedToken.java
@@ -1,0 +1,11 @@
+package fr.lehtto.jaser.dns.master.file;
+
+/**
+ * A token parsed.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+record ParsedToken(String value, ParseTokenStateMachine type) {
+
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParserInputContext.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/ParserInputContext.java
@@ -1,0 +1,141 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import fr.lehtto.jaser.dns.entity.enumration.DnsClass;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Context for the parser.
+ *
+ * @author Lehtto
+ * @version 0.2.0
+ */
+class ParserInputContext {
+
+  private final List<String> lines = new ArrayList<>();
+  private int lineIndex = -1;
+
+  // region stated fields
+  private @NotNull String domain;
+  private Integer ttl;
+  private DnsClass dnsClass;
+
+  // endregion
+
+  /**
+   * Valued constructor.
+   *
+   * @param lines the lines to parse
+   * @param domain the zone to parse
+   */
+  ParserInputContext(final List<String> lines, final @NotNull String domain) {
+    setLines(lines);
+    this.domain = domain;
+  }
+
+
+  /**
+   * Sets the lines to parse.
+   *
+   * @param lines the lines to parse
+   */
+  private void setLines(final @Nullable List<String> lines) {
+    this.lines.clear();
+    if (null != lines) {
+      this.lines.addAll(lines);
+    }
+  }
+
+  /**
+   * Gets the stated domain.
+   *
+   * @return the stated domain
+   */
+  @NotNull String getDomain() {
+    return domain;
+  }
+
+  /**
+   * Sets the stated domain.
+   *
+   * @param domain the domain to set
+   */
+  void setDomain(final @NotNull String domain) {
+    this.domain = domain;
+  }
+
+  /**
+   * Gets the stated TTL.
+   *
+   * @return the stated TTL
+   */
+  @Nullable Integer getTtl() {
+    return ttl;
+  }
+
+  /**
+   * Sets the stated TTL.
+   *
+   * @param ttl the TTL to set
+   */
+  void setTtl(final Integer ttl) {
+    this.ttl = ttl;
+  }
+
+  /**
+   * Gets the stated dns class.
+   *
+   * @return the stated dns class
+   */
+  @Nullable DnsClass getDnsClass() {
+    return dnsClass;
+  }
+
+  /**
+   * Sets the stated DNS class.
+   *
+   * @param dnsClass the DNS class to set
+   */
+  void setDnsClass(final DnsClass dnsClass) {
+    this.dnsClass = dnsClass;
+  }
+
+  /**
+   * Gets the next line to parse.
+   *
+   * @return the next line to parse
+   */
+  String nextLine() {
+    ++lineIndex;
+    return lines.get(lineIndex);
+  }
+
+  /**
+   * Checks if the current line is the last one.
+   *
+   * @return true if the current line is the last one, false otherwise
+   */
+  boolean hasNextLine() {
+    return lineIndex + 1 < lines.size();
+  }
+
+  /**
+   * Gets the current line index.
+   *
+   * @return the current line index
+   */
+  int getLineIndex() {
+    return lineIndex;
+  }
+
+  /**
+   * Adds lines to the context.
+   *
+   * @param includedLines the lines to add
+   */
+  void addLines(final List<String> includedLines) {
+    lines.addAll(lineIndex + 1, includedLines);
+  }
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/Token.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/Token.java
@@ -1,0 +1,13 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A token is a piece of data that is separated by a separator.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+record Token(@NotNull String value, @NotNull TokenType type) {
+
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/TokenType.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/TokenType.java
@@ -1,0 +1,20 @@
+package fr.lehtto.jaser.dns.master.file;
+
+/**
+ * Type of token.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+enum TokenType {
+  DOMAIN,
+  COMMENT,
+  CONTROL,
+  DATA,
+  QUOTE,
+  END_QUOTE,
+  NEWLINE,
+  SPACE,
+  START,
+  INVALID
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/master/file/TokenizeStateMachine.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/master/file/TokenizeStateMachine.java
@@ -1,0 +1,188 @@
+package fr.lehtto.jaser.dns.master.file;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * State machine to tokenize a line.
+ *
+ * @author lehtto
+ * @since 0.2.0
+ */
+enum TokenizeStateMachine {
+  START {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      if (Character.isAlphabetic(c)) {
+        return DOMAIN;
+      }
+      return switch (c) {
+        case ';' -> COMMENT;
+        case '$' -> CONTROL;
+        case ' ', '\t' -> SPACE;
+        case '\n' -> NEWLINE;
+        default -> INVALID;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.START;
+    }
+  },
+  COMMENT {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '\n' -> NEWLINE;
+        default -> COMMENT;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.COMMENT;
+    }
+  },
+  CONTROL {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '\n' -> NEWLINE;
+        case '\t', ' ' -> SPACE;
+        default -> CONTROL;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.CONTROL;
+    }
+  },
+  DOMAIN {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '\t', ' ' -> SPACE;
+        case '\n' -> NEWLINE;
+        case ';' -> COMMENT;
+        default -> DOMAIN;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.DOMAIN;
+    }
+  },
+  SPACE {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case ' ', '\t' -> SPACE;
+        case '\n' -> NEWLINE;
+        case ';' -> COMMENT;
+        case '"' -> QUOTE;
+        default -> DATA;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.SPACE;
+    }
+  },
+  DATA {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '\t', ' ' -> SPACE;
+        case '\n' -> NEWLINE;
+        case ';' -> COMMENT;
+        default -> DATA;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.DATA;
+    }
+  },
+  QUOTE {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '"' -> END_QUOTE;
+        default -> QUOTE;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.QUOTE;
+    }
+  },
+  END_QUOTE {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return switch (c) {
+        case '\t', ' ' -> SPACE;
+        case '\n' -> NEWLINE;
+        case ';' -> COMMENT;
+        default -> INVALID;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.END_QUOTE;
+    }
+  },
+  NEWLINE {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      if (Character.isAlphabetic(c)) {
+        return DOMAIN;
+      }
+
+      return switch (c) {
+        case ';' -> COMMENT;
+        case '$' -> CONTROL;
+        case ' ', '\t' -> SPACE;
+        case '\n' -> NEWLINE;
+        default -> INVALID;
+      };
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.NEWLINE;
+    }
+  },
+  INVALID {
+    @Override
+    public TokenizeStateMachine next(final char c) {
+      return INVALID;
+    }
+
+    @Override
+    public @NotNull TokenType getType() {
+      return TokenType.INVALID;
+    }
+  }
+  ;
+
+  /**
+   * Gets the next state based on character.
+   *
+   * @param c the character to check
+   * @return the next state
+   */
+  public abstract TokenizeStateMachine next(final char c);
+
+  /**
+   * Gets the type of the token.
+   *
+   * @return the type of the token
+   */
+  public abstract @NotNull TokenType getType();
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/AQueryHandler.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/AQueryHandler.java
@@ -9,6 +9,7 @@ import fr.lehtto.jaser.dns.entity.ResourceRecord;
 import fr.lehtto.jaser.dns.entity.Response;
 import fr.lehtto.jaser.dns.entity.enumration.QR;
 import fr.lehtto.jaser.dns.entity.enumration.RCode;
+import fr.lehtto.jaser.dns.master.file.MasterFile;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,8 +37,10 @@ final class AQueryHandler implements QueryHandler {
     final Question question = query.questions().get(0);
 
     // TODO refactor this
-    final List<ResourceRecord> answers = Dns.INSTANCE.getMasterFile()
+    final List<ResourceRecord> answers = Dns.INSTANCE.getMasterFiles()
         .stream()
+        .map(MasterFile::getRecords)
+        .flatMap(List::stream)
         .filter(resourceRecord -> resourceRecord.recordClass() == question.recordClass())
         .filter(resourceRecord -> resourceRecord.type() == question.type())
         .filter(resourceRecord -> question.nameMatch(resourceRecord.name()))

--- a/dnsZone.txt
+++ b/dnsZone.txt
@@ -1,8 +1,0 @@
-example.com 150 IN A 192.168.0.1
-example.com 150 IN AAA 8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff
-example.com 150 IN MX 10 mail.example.com
-example.com 150 IN NS ns1.example.com
-example.com 150 IN TXT "1|localhost test"
-example.com 150 IN CNAME www.example.com
-example.com 150 IN SOA ns1.example.com. hostmaster.example.com. 1 1 1 1 1
-example.com 150 IN HINFO "Intel core i5 (x86_64)" "Macintosh 12.4 (Monterey)"

--- a/example.com.zone
+++ b/example.com.zone
@@ -1,0 +1,22 @@
+; ZONE example.com for IN class
+$TTL 20
+$CLASS IN
+      150 IN SOA ns1.example.com. hostmaster.example.com. 1 1 1 1 1
+      150 IN A 192.168.0.1
+forum 150 IN A 192.168.0.1
+          IN AAA 8888:9999:aaaa:bbbb:cccc:dddd:eeee:ffff
+          IN 150 MX 10 mail.example.com ; TTL after class
+      150    NS ns1.example.com
+             TXT "1|localhost test"
+
+; ZONE example.com for IN class
+test.example.fr. 150 IN A 192.168.0.1
+
+; ZONE example.com for IN class
+$ORIGIN example.be.
+ 150 IN A 192.168.0.1
+
+; ZONE sub.example.com for IN class
+$INCLUDE sub.example.com.zone
+example.com. 150 IN CNAME www.example.com
+example.com. 150 IN HINFO "Intel core i5 (x86_64)" "Macintosh 12.4 (Monterey)"

--- a/sub.example.com.zone
+++ b/sub.example.com.zone
@@ -1,0 +1,4 @@
+; ZONE sub.example.com for IN class
+sub.example.com 150 IN A 192.168.0.1
+sub.example.com 150 IN NS ns1.example.com.
+sub.example.com 150 IN NS ns2.example.com.


### PR DESCRIPTION
- Support more than one DNS zone
- Enhance file parsing:
  - Support comment
  - Support optional values
  - Support control lines

BREAKING CHANGE: Dns class + Command option's default

Dns class have a list of `MasterFile` instead of list of `ResourceRecord`
File command option is no more defaulted