### PR TITLE
fix(dns): Handle reverse query 🐛

### DIFF
--- a/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/DefaultQueryHandler.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/DefaultQueryHandler.java
@@ -1,0 +1,30 @@
+package fr.lehtto.jaser.dns.query.handler;
+
+import fr.lehtto.jaser.dns.entity.Query;
+import fr.lehtto.jaser.dns.entity.Response;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link QueryHandler Query handler} for A (IPv4) query.
+ *
+ * @author lehtto
+ * @since  0.1.0
+ * @version 0.2.0
+ */
+final class DefaultQueryHandler implements QueryHandler {
+
+  static final DefaultQueryHandler INSTANCE = new DefaultQueryHandler();
+
+  /**
+   * Default constructor.
+   */
+  private DefaultQueryHandler() {
+    // This constructor should not be called
+  }
+
+  @Override
+  public @NotNull Response handleValidatedQuery(final @NotNull Query query) {
+    LOG.warn("Unsupported query type: {}", query.questions().get(0).type());
+    return QueryHandlerHelper.INSTANCE.newNotImplementedResponse(query);
+  }
+}

--- a/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/QueryHandlerFactory.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/QueryHandlerFactory.java
@@ -30,7 +30,7 @@ public final class QueryHandlerFactory {
       case A -> AQueryHandler.INSTANCE;
       case NS -> NSQueryHandler.INSTANCE;
       case CNAME -> CnameQueryHandler.INSTANCE;
-      default -> throw new IllegalArgumentException("Unsupported query type");
+      default -> DefaultQueryHandler.INSTANCE;
     };
   }
 }

--- a/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/QueryHandlerHelper.java
+++ b/dns/src/main/java/fr/lehtto/jaser/dns/query/handler/QueryHandlerHelper.java
@@ -2,9 +2,13 @@ package fr.lehtto.jaser.dns.query.handler;
 
 import fr.lehtto.jaser.dns.Dns;
 import fr.lehtto.jaser.dns.entity.DomainName;
+import fr.lehtto.jaser.dns.entity.Query;
 import fr.lehtto.jaser.dns.entity.Question;
 import fr.lehtto.jaser.dns.entity.ResourceRecord;
 import fr.lehtto.jaser.dns.entity.ResourceRecord.Builder;
+import fr.lehtto.jaser.dns.entity.Response;
+import fr.lehtto.jaser.dns.entity.enumration.QR;
+import fr.lehtto.jaser.dns.entity.enumration.RCode;
 import fr.lehtto.jaser.dns.entity.rdata.MultiNamedRData;
 import fr.lehtto.jaser.dns.entity.rdata.NamedRData;
 import fr.lehtto.jaser.dns.master.file.Zone;
@@ -72,6 +76,30 @@ final class QueryHandlerHelper {
       }
     }
     return List.copyOf(result);
+  }
+
+  /**
+   * Creates a response with not implemented error.
+   *
+   * @param query the query to answer
+   * @return the response
+   */
+  Response newNotImplementedResponse(final @NotNull Query query) {
+    return Response.builder()
+        .header(query.header()
+            .toBuilder()
+            .flags(query.header()
+                .flags()
+                .toBuilder()
+                .qr(QR.RESPONSE)
+                .rcode(RCode.NOT_IMPLEMENTED)
+                .build())
+            .build())
+        .questions(query.questions())
+        .noAnswer()
+        .noAuthorityRecords()
+        .noAdditionalRecords()
+        .build();
   }
 
   /**


### PR DESCRIPTION
- Return a `not implemented` for reverse query.
- Return a `not implemented` for not implemented query type.

fixes: JAS-6